### PR TITLE
Add user model and service

### DIFF
--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,0 +1,38 @@
+class User {
+  final String id;
+  final String name;
+  final String email;
+  final String password;
+  final String phone;
+  final String address;
+
+  User({
+    required this.id,
+    required this.name,
+    required this.email,
+    required this.password,
+    required this.phone,
+    required this.address,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      'email': email,
+      'password': password,
+      'phone': phone,
+      'address': address,
+    };
+  }
+
+  factory User.fromMap(String id, Map<String, dynamic> map) {
+    return User(
+      id: id,
+      name: map['name'] ?? '',
+      email: map['email'] ?? '',
+      password: map['password'] ?? '',
+      phone: map['phone'] ?? '',
+      address: map['address'] ?? '',
+    );
+  }
+}

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -1,0 +1,73 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/user.dart';
+
+class UserService {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final CollectionReference _usersCollection = FirebaseFirestore.instance.collection('users');
+
+  Future<void> createUser(User user) async {
+    try {
+      await _usersCollection.doc(user.id).set(user.toMap());
+    } catch (e) {
+      print('Error creating user: $e');
+      rethrow;
+    }
+  }
+
+  Future<User?> getUserByEmail(String email) async {
+    try {
+      QuerySnapshot snapshot = await _usersCollection.where('email', isEqualTo: email).limit(1).get();
+      if (snapshot.docs.isNotEmpty) {
+        final doc = snapshot.docs.first;
+        return User.fromMap(doc.id, doc.data() as Map<String, dynamic>);
+      }
+      return null;
+    } catch (e) {
+      print('Error getting user by email: $e');
+      rethrow;
+    }
+  }
+
+  Future<User?> getUserById(String id) async {
+    try {
+      DocumentSnapshot doc = await _usersCollection.doc(id).get();
+      if (doc.exists) {
+        return User.fromMap(doc.id, doc.data() as Map<String, dynamic>);
+      }
+      return null;
+    } catch (e) {
+      print('Error getting user by id: $e');
+      rethrow;
+    }
+  }
+
+  Future<List<User>> getUsers() async {
+    try {
+      QuerySnapshot snapshot = await _usersCollection.get();
+      return snapshot.docs
+          .map((doc) => User.fromMap(doc.id, doc.data() as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      print('Error getting users: $e');
+      rethrow;
+    }
+  }
+
+  Future<void> updateUser(String id, User user) async {
+    try {
+      await _usersCollection.doc(id).update(user.toMap());
+    } catch (e) {
+      print('Error updating user: $e');
+      rethrow;
+    }
+  }
+
+  Future<void> deleteUser(String id) async {
+    try {
+      await _usersCollection.doc(id).delete();
+    } catch (e) {
+      print('Error deleting user: $e');
+      rethrow;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `User` model with mapping helpers
- implement Firestore-backed `UserService`

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8305410883308b4a1b4890ae8a55