### PR TITLE
Implement basic Firebase sign-up

### DIFF
--- a/lib/screens/home/login_screen.dart
+++ b/lib/screens/home/login_screen.dart
@@ -159,6 +159,7 @@ class _LoginScreenState extends State<LoginScreen> {
               top: screenHeight * 650 / 932,
               child: GestureDetector(
                 onTap: () {
+                  // TODO: integrate FirebaseAuth sign in
                   Navigator.pushReplacementNamed(context, '/bottomNav');
                 },
                 child: Container(

--- a/lib/screens/home/signup_screen.dart
+++ b/lib/screens/home/signup_screen.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: deprecated_member_use
 
 import 'package:flutter/material.dart';
+import '../../services/auth_service.dart';
 
 class SignUpScreen extends StatefulWidget {
   const SignUpScreen({super.key});
@@ -14,6 +15,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
   final TextEditingController _passwordController = TextEditingController();
   final TextEditingController _nameController = TextEditingController();
   bool _isPasswordVisible = false;
+  bool _isLoading = false;
 
   @override
   void dispose() {
@@ -177,9 +179,39 @@ class _SignUpScreenState extends State<SignUpScreen> {
               left: screenWidth * 41 / 430,
               top: screenHeight * 680 / 932,
               child: GestureDetector(
-                onTap: () {
-                  // 这里可以添加注册逻辑
-                  Navigator.pushReplacementNamed(context, '/login');
+                onTap: () async {
+                  if (_nameController.text.isEmpty ||
+                      _emailController.text.isEmpty ||
+                      _passwordController.text.isEmpty) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Please fill in all fields')),
+                    );
+                    return;
+                  }
+
+                  setState(() {
+                    _isLoading = true;
+                  });
+
+                  try {
+                    await AuthService().signUp(
+                      name: _nameController.text.trim(),
+                      email: _emailController.text.trim(),
+                      password: _passwordController.text.trim(),
+                    );
+                    if (!mounted) return;
+                    Navigator.pushReplacementNamed(context, '/login');
+                  } catch (e) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Sign up failed: $e')),
+                    );
+                  } finally {
+                    if (mounted) {
+                      setState(() {
+                        _isLoading = false;
+                      });
+                    }
+                  }
                 },
                 child: Container(
                   width: screenWidth * 337 / 430,
@@ -196,15 +228,20 @@ class _SignUpScreenState extends State<SignUpScreen> {
                     ],
                   ),
                   child: Center(
-                    child: Text(
-                      'Sign Up',
-                      style: TextStyle(
-                        fontFamily: 'InknutAntiqua',
-                        fontWeight: FontWeight.bold,
-                        fontSize: screenWidth * 30 / 430,
-                        color: Colors.white,
-                      ),
-                    ),
+                    child: _isLoading
+                        ? const CircularProgressIndicator(
+                            valueColor:
+                                AlwaysStoppedAnimation<Color>(Colors.white),
+                          )
+                        : Text(
+                            'Sign Up',
+                            style: TextStyle(
+                              fontFamily: 'InknutAntiqua',
+                              fontWeight: FontWeight.bold,
+                              fontSize: screenWidth * 30 / 430,
+                              color: Colors.white,
+                            ),
+                          ),
                   ),
                 ),
               ),

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,36 @@
+import 'package:firebase_auth/firebase_auth.dart' as fb;
+
+import '../models/user.dart';
+import 'user_service.dart';
+
+class AuthService {
+  final fb.FirebaseAuth _auth = fb.FirebaseAuth.instance;
+  final UserService _userService = UserService();
+
+  Future<void> signUp({
+    required String name,
+    required String email,
+    required String password,
+  }) async {
+    try {
+      final credential = await _auth.createUserWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+      final uid = credential.user?.uid;
+      if (uid != null) {
+        final user = User(
+          id: uid,
+          name: name,
+          email: email,
+          password: password,
+          phone: '',
+          address: '',
+        );
+        await _userService.createUser(user);
+      }
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   image_picker: ^1.1.2
   firebase_core: ^3.14.0
   cloud_firestore: ^5.6.9
+  firebase_auth: ^4.17.0
   provider: ^6.1.5
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add `firebase_auth` dependency
- implement `AuthService` with sign-up logic
- handle sign-up via `AuthService` and show loading indicator
- hint at Firebase login logic in `LoginScreen`

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e88bd31308330b8c4eda47e87513d